### PR TITLE
refactor: develeop perform use to promise.all

### DIFF
--- a/src/controllers/DownloadTrackerController.ts
+++ b/src/controllers/DownloadTrackerController.ts
@@ -60,28 +60,33 @@ export default class DownloadTracker {
   }
 
   private async getWeeklyDownloadsDefault(packageName: string) {
-    const weekPack: Packages[] = [];
     const { startDate, endDate } = this.startSettingDate();
 
-    for (let i = 0; i < this.weekNum; i++) {
-      const { start, end } = this.setWeekData(startDate, endDate, i);
+    const promises = Array.from({ length: this.weekNum }).map((_, index) => {
+      const { start, end } = this.setWeekData(startDate, endDate, index);
 
-      const pack = await this.getDownloadsForWeek(
+      return this.getDownloadsForWeek(
         packageName,
         formatDate(start),
         formatDate(end),
       );
+    });
 
-      weekPack.push(pack);
+    try {
+      return await Promise.all(promises);
+    } catch (error) {
+      console.error(error);
     }
-
-    return weekPack;
   }
 
   private async getWeekPacks() {
-    for (const packageName of this.packages) {
-      const weekPack = await this.getWeeklyDownloadsDefault(packageName);
-      this.weekPacks.push(weekPack);
+    const promises = this.packages.map((packageName) => {
+      return this.getWeeklyDownloadsDefault(packageName);
+    });
+    try {
+      return await Promise.all(promises);
+    } catch (error) {
+      console.error(error);
     }
   }
 
@@ -102,7 +107,7 @@ export default class DownloadTracker {
   }
 
   public async start() {
-    await this.getWeekPacks();
-    return this.weekPacks;
+    return await this.getWeekPacks();
+    // return this.weekPacks;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ async function measurePerformance(callback) {
 
 (async () => {
   await measurePerformance(async () => {
-    const tracker = new DownloadTracker(PACKAGES, 1);
+    const tracker = new DownloadTracker(PACKAGES, 10);
     const datas = await tracker.start();
     console.log(datas);
   });


### PR DESCRIPTION
I used a parallelization promise.all to improve performance. I also used the performance measurement function to measure the speed. It's definitely faster and I'll be releasing a version. 
also, The reason for not using settled is to avoid showing incorrect data when charting later.  If the communication fails or there is an error, you should rerun it, not just put in random data. 