### PR TITLE
chore: extract performance benchmark logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "start": "tsx --watch ./src/index.ts",
     "test": "vitest",
     "build": "tsc",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "perf": "tsx ./perf/index.ts"
   },
   "dependencies": {
     "axios": "^1.6.7"

--- a/perf/index.ts
+++ b/perf/index.ts
@@ -1,0 +1,32 @@
+import { DownloadTracker } from '../src';
+
+const packages = [
+  '@sd-jwt/core',
+  // '@sd-jwt/decode',
+  // '@sd-jwt/utils',
+  // '@sd-jwt/types',
+  // '@sd-jwt/sd-jwt-vc',
+  // '@sd-jwt/present',
+  // '@sd-jwt/hash',
+  // '@sd-jwt/crypto-nodejs',
+  // '@sd-jwt/crypto-browser',
+  // '@hopae/sd-jwt',
+];
+
+const numberOfWeeks = 10;
+
+async function measurePerformance(callback) {
+  const startTime = Date.now();
+  await callback();
+  const endTime = Date.now();
+  const executionTime = endTime - startTime;
+  console.log(`Execution time: ${executionTime / 1000} seconds`);
+}
+
+(async () => {
+  await measurePerformance(async () => {
+    const tracker = new DownloadTracker(packages, numberOfWeeks);
+    const datas = await tracker.start();
+    console.log(datas);
+  });
+})();

--- a/src/controllers/DownloadTrackerController.ts
+++ b/src/controllers/DownloadTrackerController.ts
@@ -112,8 +112,6 @@ export default class DownloadTracker {
     allDatas['allTotalDownloads'] = totals;
     allDatas['weekResult'] = results;
 
-    console.log(allDatas);
-
     // OutputView.printTotalDownloads(totals);
     // OutputView.printWeekPackageName(results);
     return allDatas;

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,14 +1,1 @@
-export const WEEK_NUM = 4;
-export const PACKAGES = [
-  '@sd-jwt/core',
-  // '@sd-jwt/decode',
-  // '@sd-jwt/utils',
-  // '@sd-jwt/types',
-  // '@sd-jwt/sd-jwt-vc',
-  // '@sd-jwt/present',
-  // '@sd-jwt/hash',
-  // '@sd-jwt/crypto-nodejs',
-  // '@sd-jwt/crypto-browser',
-  // '@hopae/sd-jwt',
-];
 export const URL = 'https://api.npmjs.org/downloads/point/';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,4 @@
-import { WEEK_NUM, PACKAGES } from './data';
 import DownloadTracker from './controllers/DownloadTrackerController';
 import { PackagesType, AllPackagesType } from './type/PackageType';
 
 export { DownloadTracker, PackagesType, AllPackagesType };
-
-async function measurePerformance(callback) {
-  const startTime = Date.now();
-  await callback();
-  const endTime = Date.now();
-  const executionTime = endTime - startTime;
-  console.log(`Execution time: ${executionTime / 1000} seconds`);
-}
-
-(async () => {
-  await measurePerformance(async () => {
-    const tracker = new DownloadTracker(PACKAGES, 10);
-    const datas = await tracker.start();
-    console.log(datas);
-  });
-})();


### PR DESCRIPTION
The performance benchmark script has been extracted to ./perf/index.ts
I added a test script in package.json. you can run it with `pnpm run perf`

It closes #9 